### PR TITLE
Tagged example tables

### DIFF
--- a/TickSpec/FeatureSource.fs
+++ b/TickSpec/FeatureSource.fs
@@ -28,9 +28,11 @@ and LineSource =
         Doc : string option
     }
 and [<System.Diagnostics.DebuggerStepThrough>]
-    Table (header:string[],rows:string[][]) =    
-    new (header) = Table(header,[|[||]|])
+    Table (header:string[],rows:string[][],tags:string[]) =    
+    new (header, rows) = Table(header,rows,[||])
+    new (header) = Table(header,[|[||]|],[||])
     new () = Table([||]) 
     member table.Header = header
     member table.Rows = rows
+    member table.Tags = tags
     member table.Raw = [|yield header;yield! rows|] 


### PR DESCRIPTION
The basic idea behind this change is: _"find the least readable part of the codee and make it even less readable"_

A bit more seriously:

- The tags:string[] member added into the Tabe class. The array is empty by default.
- In the `buildBlocks` function, there we add some more tags handling:
  - In the `tags` variable, there we have a tags from current block (not necessarily the table tags)
  - In the `tags'` variable, there we have a tags from previous block (not useful for us too)
  - So we are adding the `lastTags: string[]` variable where we keep tags only for the next iteration (next line). When we encounter the `ExamplesStart` line, we use the `lastTags` to propagate the table tags further.
  - In the `mapItems` function, there we use it for construction the `Table`.
- Any comments are welcome, @mchaloupka, @michalkovy 
